### PR TITLE
Query all posts and add all button to category drawer

### DIFF
--- a/src/Routes.js
+++ b/src/Routes.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { BrowserRouter, Route, Switch } from 'react-router-dom'
 
 // Import Views
-import Category from './views/Category'
+import Category, { allPosts } from './views/Category'
 import Home from './views/Home'
 import PostDetail from './views/PostDetail'
 
@@ -11,6 +11,7 @@ const Routes = () => {
     <BrowserRouter>
       <Switch>
         <Route exact path="/" component={Home} />
+        <Route exact path="/category/" component={allPosts} />
         <Route exact path="/category/:slug" component={Category} />
         <Route path="/post/:post_id" component={PostDetail} />
       </Switch>

--- a/src/components/Layout/drawer.js
+++ b/src/components/Layout/drawer.js
@@ -12,6 +12,32 @@ import AlarmClock from 'material-ui-icons/Alarm'
 import ClockIcon from 'material-ui-icons/AccessTime'
 import { graphql } from 'react-apollo'
 
+const displayCategories = props => {
+  const { data, classes } = props
+  if (data.loading) return
+
+  return (
+    <div>
+      <Link to={`/category/`} className={classes.link}>
+        <ListItem button>
+          <ListItemText secondary={`All`} />
+        </ListItem>
+      </Link>
+      {data.categories.edges.map(category => (
+        <Link
+          key={category.node.id}
+          to={`/category/${category.node.slug}`}
+          className={classes.link}
+        >
+          <ListItem button>
+            <ListItemText secondary={category.node.name} />
+          </ListItem>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
 class SideComponent extends Component {
   render () {
     const classes = this.props.classes
@@ -44,19 +70,7 @@ class SideComponent extends Component {
         </Link>
         <Divider />
         <ListSubheader>Categories</ListSubheader>
-        {!this.props.data.loading &&
-          this.props.data.categories &&
-          this.props.data.categories.edges.map(category => (
-            <Link
-              key={category.node.id}
-              to={`/category/${category.node.slug}`}
-              className={classes.link}
-            >
-              <ListItem button>
-                <ListItemText secondary={category.node.name} />
-              </ListItem>
-            </Link>
-          ))}
+        {displayCategories(this.props)}
         <Divider />
         <ListItem button>
           <ListItemIcon>

--- a/src/views/Category.js
+++ b/src/views/Category.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { graphql } from 'react-apollo'
-import { getPostsByCat } from '../graphql/queries/posts'
+import { getPostsByCat, getAllPosts } from '../graphql/queries/posts'
 import Loader from '../components/Loader'
 import Layout from '../components/Layout/index'
 import { Helmet } from 'react-helmet'
@@ -8,7 +8,10 @@ import { Helmet } from 'react-helmet'
 import GridRenderer from '../components/GridTypes/GridRenderer'
 import Error from '../components/Error'
 
-const Category = ({ data, viewtype }) => {
+const Category = ({ data, viewtype }) => RenderLayout(data, viewtype)
+const AllPosts = ({ data, viewtype }) => RenderLayout(data, viewtype)
+
+const RenderLayout = (data, viewtype) => {
   const isLoading = data.loading
   return (
     <Layout>
@@ -18,6 +21,7 @@ const Category = ({ data, viewtype }) => {
     </Layout>
   )
 }
+
 const RenderCategories = ({ data, viewtype }) => {
   const posts = data.posts
   return (
@@ -35,3 +39,5 @@ const RenderCategories = ({ data, viewtype }) => {
 export default graphql(getPostsByCat, {
   options: ({ match }) => ({ variables: { slug: match.params.slug } })
 })(Category)
+
+export const allPosts = graphql(getAllPosts)(AllPosts)


### PR DESCRIPTION
Pr for #18 

I didn't want to change to much with the general structure, so I added a stateless component in drawer.js to handle the All Category button. I also created a new smart component for the all posts. It could be it's own file, but since most of the logic retained still to category, I left it in the category view. I can always extract it more.

I was not able to use the orderBy keyword in apollo. Don't have a ton of GraphQL/Apollo experience, so lemme know if you have any ideas :).

<img width="1357" alt="screen shot 2017-10-18 at 2 59 53 pm" src="https://user-images.githubusercontent.com/1203369/31742517-1231e7e0-b415-11e7-8d31-f9f05b75faea.png">
